### PR TITLE
Removing unnecessary mount of engine route

### DIFF
--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,5 +3,4 @@ Rails.application.routes.draw do
   get 'pages/about'
 
   resources :posts
-  mount ReactParticles::Engine => "/react_particles" # necessary unless mounting with initializer in engine
 end


### PR DESCRIPTION
- Removed mount ReactParticles::Engine mount in test/dummy/config/routes.rb
- Allowing dynamic mounting of engine defined by user input with --namespace

**e.g. with --namespace:**  

`$ rails g react_particles:install  --namespace reakt_app`

```
      create  app/controllers/reakt_app/application_controller.rb

      create  app/controllers/reakt_app/components_controller.rb

      create  app/views/reakt_app/components/index.html.erb

       route  scope module: 'reakt_app' do
                 get 'components/index'
              end
```

**e.g. without --namespace:**  

` $ rails g react_particles:install `
```
create  app/controllers/react_application/application_controller.rb

      create  app/controllers/react_application/components_controller.rb

      create  app/views/react_application/components/index.html.erb

       route  scope module: 'react_application' do
                 get 'components/index'
              end
```


